### PR TITLE
Fix issue 2.2

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -76,7 +76,7 @@ jobs:
           MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
           PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
           NEXT_PATCH=$((PATCH + 1))
-          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-pre"
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-alpha"
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
 
       - name: Bump version to next pre-release

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -49,3 +49,35 @@ jobs:
             ${{ env.IMG }}:${{ env.version_major }}.${{ env.version_minor }}.latest
             ${{ env.IMG }}:${{ env.version_major }}.latest
             ${{ env.IMG }}:latest
+
+bump-version:
+    runs-on: ubuntu-24.04
+    needs: build-and-push
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+
+      - name: Install bumpver
+        run: pip install bumpver
+
+      - name: Determine next pre-release version
+        id: next_version
+        run: |
+          CURRENT_VERSION=${GITHUB_REF#refs/tags/v}
+          NEXT_VERSION=$(echo $CURRENT_VERSION | awk -F. '{print $1 "." $2 "." $3+1 "-pre"}')
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_ENV
+
+      - name: Bump version to next pre-release
+        run: bumpver update --new-version ${{ env.next_version }}
+
+      - name: Commit and push changes
+        run: |
+          git add pyproject.toml
+          git commit -m "Bump version to ${{ env.next_version }}"
+          git push origin main

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,6 +3,7 @@ name: Build and Push app-service Image
 on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    branches: ["fix-issue-2-2"]
 
 env:
   IMG: ghcr.io/${{ github.repository }}
@@ -50,11 +51,12 @@ jobs:
             ${{ env.IMG }}:${{ env.version_major }}.latest
             ${{ env.IMG }}:latest
 
-bump-version:
+  bump-version:
     runs-on: ubuntu-24.04
     needs: build-and-push
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout main branch
+        uses: actions/checkout@v4
         with:
           ref: main
 
@@ -67,17 +69,21 @@ bump-version:
         run: pip install bumpver
 
       - name: Determine next pre-release version
-        id: next_version
+        id: set_version
         run: |
           CURRENT_VERSION=${GITHUB_REF#refs/tags/v}
-          NEXT_VERSION=$(echo $CURRENT_VERSION | awk -F. '{print $1 "." $2 "." $3+1 "-pre"}')
-          echo "next_version=$NEXT_VERSION" >> $GITHUB_ENV
+          MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+          MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+          PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-pre"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
 
       - name: Bump version to next pre-release
-        run: bumpver update --new-version ${{ env.next_version }}
+        run: bumpver update --new-version ${{ env.NEXT_VERSION }}
 
       - name: Commit and push changes
         run: |
           git add pyproject.toml
-          git commit -m "Bump version to ${{ env.next_version }}"
+          git commit -m "chore: bump version to ${{ env.NEXT_VERSION }} after release"
           git push origin main

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,7 +3,6 @@ name: Build and Push app-service Image
 on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
-    branches: ["fix-issue-2-2"]
 
 env:
   IMG: ghcr.io/${{ github.repository }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -9,47 +9,47 @@ env:
   IMG: ghcr.io/${{ github.repository }}
 
 jobs:
-  # build-and-push:
-  #   runs-on: ubuntu-24.04
-  #   permissions:
-  #     contents: read
-  #     packages: write
+  build-and-push:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Parse version info from tag
-  #       run: |
-  #         VERSION=${GITHUB_REF#refs/tags/}
-  #         MAJOR=$(echo "$VERSION" | cut -d . -f 1)
-  #         MINOR=$(echo "$VERSION" | cut -d . -f 2)
-  #         PATCH=$(echo "$VERSION" | cut -d . -f 3)
-  #         echo "version=$VERSION" >> $GITHUB_ENV
-  #         echo "version_major=$MAJOR" >> $GITHUB_ENV
-  #         echo "version_minor=$MINOR" >> $GITHUB_ENV
-  #         echo "version_patch=$PATCH" >> $GITHUB_ENV
+      - name: Parse version info from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=$(echo "$VERSION" | cut -d . -f 1)
+          MINOR=$(echo "$VERSION" | cut -d . -f 2)
+          PATCH=$(echo "$VERSION" | cut -d . -f 3)
+          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "version_major=$MAJOR" >> $GITHUB_ENV
+          echo "version_minor=$MINOR" >> $GITHUB_ENV
+          echo "version_patch=$PATCH" >> $GITHUB_ENV
 
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Build and push multi-arch image
-  #       uses: docker/build-push-action@v5
-  #       with:
-  #         context: .
-  #         push: true
-  #         platforms: linux/amd64,linux/arm64
-  #         tags: |
-  #           ${{ env.IMG }}:${{ env.version }}
-  #           ${{ env.IMG }}:${{ env.version_major }}.${{ env.version_minor }}.latest
-  #           ${{ env.IMG }}:${{ env.version_major }}.latest
-  #           ${{ env.IMG }}:latest
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMG }}:${{ env.version }}
+            ${{ env.IMG }}:${{ env.version_major }}.${{ env.version_minor }}.latest
+            ${{ env.IMG }}:${{ env.version_major }}.latest
+            ${{ env.IMG }}:latest
 
   bump-version:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -80,7 +80,7 @@ jobs:
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
 
       - name: Bump version to next pre-release
-        run: bumpver update --new-version ${{ env.NEXT_VERSION }}
+        run: bumpver update --set-version ${{ env.NEXT_VERSION }}
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -9,47 +9,47 @@ env:
   IMG: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
+  # build-and-push:
+  #   runs-on: ubuntu-24.04
+  #   permissions:
+  #     contents: read
+  #     packages: write
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Parse version info from tag
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          MAJOR=$(echo "$VERSION" | cut -d . -f 1)
-          MINOR=$(echo "$VERSION" | cut -d . -f 2)
-          PATCH=$(echo "$VERSION" | cut -d . -f 3)
-          echo "version=$VERSION" >> $GITHUB_ENV
-          echo "version_major=$MAJOR" >> $GITHUB_ENV
-          echo "version_minor=$MINOR" >> $GITHUB_ENV
-          echo "version_patch=$PATCH" >> $GITHUB_ENV
+  #     - name: Parse version info from tag
+  #       run: |
+  #         VERSION=${GITHUB_REF#refs/tags/}
+  #         MAJOR=$(echo "$VERSION" | cut -d . -f 1)
+  #         MINOR=$(echo "$VERSION" | cut -d . -f 2)
+  #         PATCH=$(echo "$VERSION" | cut -d . -f 3)
+  #         echo "version=$VERSION" >> $GITHUB_ENV
+  #         echo "version_major=$MAJOR" >> $GITHUB_ENV
+  #         echo "version_minor=$MINOR" >> $GITHUB_ENV
+  #         echo "version_patch=$PATCH" >> $GITHUB_ENV
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Build and push multi-arch image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMG }}:${{ env.version }}
-            ${{ env.IMG }}:${{ env.version_major }}.${{ env.version_minor }}.latest
-            ${{ env.IMG }}:${{ env.version_major }}.latest
-            ${{ env.IMG }}:latest
+  #     - name: Build and push multi-arch image
+  #       uses: docker/build-push-action@v5
+  #       with:
+  #         context: .
+  #         push: true
+  #         platforms: linux/amd64,linux/arm64
+  #         tags: |
+  #           ${{ env.IMG }}:${{ env.version }}
+  #           ${{ env.IMG }}:${{ env.version_major }}.${{ env.version_minor }}.latest
+  #           ${{ env.IMG }}:${{ env.version_major }}.latest
+  #           ${{ env.IMG }}:latest
 
   bump-version:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # app-service
+
+## Instructions for creating a new release
+
+To check the current version of the app run:
+
+```zsh
+bumpver show
+```
+
+We use `-alpha` to tag a pre-release instead of `-pre`.
+
+Incrementing from alpha-release to stable is a conscious decision, so to make a stable release remove `-alpha`
+from the version, e.g. is the current version is `1.0.14-alpha` you can run
+
+```zsh
+bumpver update --set-version "1.0.14" --dry  # Remove --dry to execute
+```
+
+After this is done, you can create a matching git tag by prefixing the version with `v`,
+e.g.
+
+```zsh
+git tag v1.0.14
+```
+
+Then push the tag to origin and this will trigger a release workflow and update `main` to the next alpha release.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.1"
+current_version = "1.0.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit = true
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.13"
+version = "1.0.14-beta"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.13"
+current_version = "1.0.14-beta"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,14 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.2"
+current_version = "1.0.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit = true
 tag = true
 version_files = ["pyproject.toml:project.version"]
 
-
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+  '^version = "{version}"',  # This line will match and update the [project] version field!
+  '^current_version = "{version}"'
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,6 @@ version_files = ["pyproject.toml:project.version"]
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
-  '^version = "{version}"',  # This line will match and update the [project] version field!
+  '^version = "{version}"',  #  Matches and updates the [project] version field
   '^current_version = "{version}"'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.12"
+version = "1.0.13"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.12"
+current_version = "1.0.13"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = true
@@ -37,6 +37,6 @@ version_files = ["pyproject.toml:project.version"]
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
-  '^version = "{version}"',
-  '^current_version = "{version}"'
+    '^version = "{version}"',
+    '^current_version = "{version}"'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.10"
+version = "1.0.12"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.10"
+current_version = "1.0.12"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = true
@@ -37,6 +37,6 @@ version_files = ["pyproject.toml:project.version"]
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
-  '^version = "{version}"',  
+  '^version = "{version}"',
   '^current_version = "{version}"'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ pylint = "^3.3.6"
 current_version = "1.0.14-beta"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
-tag = true
+tag = false
 version_files = ["pyproject.toml:project.version"]
 
 [tool.bumpver.file_patterns]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.0"
+current_version = "1.0.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit = true
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,11 @@ black = "^25.1.0"
 isort = "^6.0.1"
 pylint = "^3.3.6"
 
+[tool.bumpver]
+current_version = "1.0.0"
+version_pattern = "MAJOR.MINOR.PATCH"
+commit = true
+tag = true
+version_files = ["pyproject.toml:project.version"]
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.14-beta"
+version = "1.0.14"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.14-beta"
+current_version = "1.0.14"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.8"
+version = "1.0.9"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.8"
+current_version = "1.0.9"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.9"
+version = "1.0.10"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.9"
+current_version = "1.0.10"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = true
@@ -37,6 +37,6 @@ version_files = ["pyproject.toml:project.version"]
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
-  '^version = "{version}"',  #  Matches and updates the [project] version field
+  '^version = "{version}"',  
   '^current_version = "{version}"'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.0"
+version = "1.0.3"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.0"
+current_version = "1.0.3"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit = true
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.3"
+version = "1.0.8"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,8 +29,8 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.3"
-version_pattern = "MAJOR.MINOR.PATCH"
+current_version = "1.0.8"
+version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = true
 version_files = ["pyproject.toml:project.version"]


### PR DESCRIPTION
This PR updates the bumpver config and version in pyproject.toml.  
Confirmed that prerelease tags like `-beta` work as expected, but `-pre` still fails with the current `version_pattern`.

Tested:
- `bumpver update --set-version 1.0.14-beta` works
- `bumpver update --set-version 1.0.14-pre` fails