### PR TITLE
Base path migration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,13 +2,28 @@ import os
 
 from flasgger import Swagger
 from flask import Flask
+from libversion import version
 
 from app.routes import register_blueprints
 
 
 def create_app():
     app = Flask(__name__)
-    swagger = Swagger(app)
+
+    swagger_template = {
+        "swagger": "2.0",
+        "info": {
+            "title": "App Service",
+            "description": "Backend service to communicate with the model",
+            "version": version.VersionUtil.get_version(),
+        },
+        "basePath": "/app",
+        "schemes": ["http"],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+    }
+
+    swagger = Swagger(app, template=swagger_template)
 
     app.config["ENV"] = os.getenv("FLASK_ENV", "production")
     app.config["DEBUG"] = os.getenv("DEBUG", "false").lower() == "true"

--- a/app/routes/predict.py
+++ b/app/routes/predict.py
@@ -21,7 +21,7 @@ def predict():
               text:
                 type: string
           example:
-              text: "your input data here"}
+              text: "your input data here"
     responses:
       200:
         description: Successful prediction
@@ -31,7 +31,7 @@ def predict():
     try:
         print(f"Data: {request.json}")
         response = requests.post(
-            f"{MODEL_SERVICE_URL}/predict", json=request.json, timeout=5
+            f"{MODEL_SERVICE_URL}/model/predict", json=request.json, timeout=5
         )
         return jsonify(response.json()), response.status_code
     except Exception as e:

--- a/app/routes/version.py
+++ b/app/routes/version.py
@@ -26,7 +26,7 @@ def get_versions():
               example: "v1.0.0"
     """
     try:
-        response = requests.get(f"{MODEL_SERVICE_URL}/version", timeout=2)
+        response = requests.get(f"{MODEL_SERVICE_URL}/model/version", timeout=2)
         model_version = response.json().get("version", "unknown")
     except Exception:
         model_version = "unreachable"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.18"
+version = "2.0.0"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.18"
+current_version = "2.0.0"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app-service"
-version = "1.0.18-alpha"
+version = "1.0.18"
 description = "Backend server for the application"
 authors = [
     {name = "shreyas",email = "shreyaskalvankar@gmail.com"}
@@ -29,7 +29,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 
 [tool.bumpver]
-current_version = "1.0.18-alpha"
+current_version = "1.0.18"
 version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
 commit = true
 tag = false

--- a/run.py
+++ b/run.py
@@ -1,17 +1,20 @@
 import os
 
 from dotenv import load_dotenv
+from flask import Flask
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.serving import run_simple
 
 from app import create_app
 
 load_dotenv()
 
 app = create_app()
-
+application = DispatcherMiddleware(Flask("dummy"), {"/app": app})
 if __name__ == "__main__":
 
     debug = app.config["DEBUG"]
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "5000"))
 
-    app.run(host=host, port=port, debug=debug)
+    run_simple(host, port, application, use_reloader=debug, use_debugger=debug)


### PR DESCRIPTION
Update the base path of the application so it lives under `/app`.

This allows us to use a reverse proxy like nginx to forward requests correctly. 

Fixes #3 